### PR TITLE
fix: use python3 -m pip instead of pip for macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,32 +11,40 @@ A cross-platform tool to back up and restore installed packages, applications, a
 
 ## How to Use
 
-### 0. Update homebrew!
+### 0. Update homebrew
+
 ```bash
 brew untap homebrew/homebrew-cask-versions
 /opt/homebrew/bin/brew update
 ```
 
 ### 1. Clone the Repository
+
 ```bash
 git clone https://github.com/tiagornandrade/backup-installer.git
 cd backup-installer
 ```
 
 ### 2. Make Scripts Executable
+
 Before running the scripts, make them executable:
+
 ```bash
 chmod +x generate_reinstall_script.sh install_dependencies.sh
 ```
 
 ### 3. Install Basic Dependencies
+
 Run the `install_dependencies.sh` script to ensure your system has the required tools installed (like Homebrew or pip):
+
 ```bash
 ./install_dependencies.sh
 ```
 
 ### 4. Generate the Reinstall Script
+
 Run the `generate_reinstall_script.sh` script to create a reinstall script based on your current system:
+
 ```bash
 ./generate_reinstall_script.sh
 ```
@@ -44,13 +52,17 @@ Run the `generate_reinstall_script.sh` script to create a reinstall script based
 This will create a `reinstall_packages.sh` file in the current directory.
 
 ### 5. Use the Reinstall Script
+
 When setting up a new machine or reinstalling everything on your current system, execute the generated `reinstall_packages.sh` script:
+
 ```bash
 ./reinstall_packages.sh
 ```
 
 ## Contribution
+
 Contributions are welcome! Feel free to open issues or submit pull requests for new features or bug fixes.
 
 ## License
+
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/generate_reinstall_script.sh
+++ b/generate_reinstall_script.sh
@@ -55,10 +55,12 @@ elif [[ "$OS" == "Linux" ]]; then
     dpkg --get-selections | awk '{print $1}' | xargs echo "sudo apt install -y" >> $OUTPUT_FILE
 fi
 
-echo "" >> $OUTPUT_FILE
-echo "# Install pip packages" >> $OUTPUT_FILE
-echo "pip install --upgrade pip" >> $OUTPUT_FILE
-pip freeze | sed 's/^/pip install /' >> $OUTPUT_FILE
+if command -v python3 > /dev/null; then
+    echo "" >> $OUTPUT_FILE
+    echo "# Install pip packages" >> $OUTPUT_FILE
+    echo "python3 -m pip install --upgrade pip" >> $OUTPUT_FILE
+    python3 -m pip freeze | sed 's/^/python3 -m pip install /' >> $OUTPUT_FILE
+fi
 
 if command -v npm > /dev/null; then
     echo "" >> $OUTPUT_FILE

--- a/reinstall_packages.sh
+++ b/reinstall_packages.sh
@@ -5,137 +5,380 @@ set -e
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew update && brew upgrade
 # Install Homebrew packages
+brew install abctl
 brew install abseil
-brew install appstream
-brew install asdf
-brew install aspell
-brew install at-spi2-core
-brew install awscli
+brew install act
+brew install antlr
+brew install aom
+brew install aribb24
 brew install brotli
 brew install c-ares
 brew install ca-certificates
-brew install cabextract
 brew install cairo
-brew install certifi
-brew install cffi
-brew install cryptography
-brew install dbus
-brew install enchant
+brew install cjson
+brew install cmake
+brew install commitizen
+brew install dav1d
+brew install docker
+brew install docker-completion
+brew install duckdb
+brew install ffmpeg
+brew install flac
+brew install fluent-bit
 brew install fontconfig
 brew install freetype
+brew install frei0r
 brew install fribidi
+brew install gd
 brew install gdk-pixbuf
 brew install gettext
 brew install gh
-brew install git
+brew install giflib
+brew install git-delta
 brew install glib
 brew install gmp
-brew install go-task
-brew install graphene
+brew install gnutls
+brew install go
+brew install gradle
 brew install graphite2
-brew install gsettings-desktop-schemas
-brew install gtk+3
-brew install gtk4
+brew install graphviz
+brew install gts
 brew install harfbuzz
-brew install hicolor-icon-theme
-brew install icu4c@76
+brew install helm
+brew install highway
 brew install icu4c@77
+brew install imath
+brew install jasper
 brew install jpeg-turbo
-brew install jq
-brew install libadwaita
-brew install libepoxy
-brew install libfyaml
+brew install jpeg-xl
+brew install lame
+brew install leptonica
+brew install libarchive
+brew install libass
+brew install libavif
+brew install libb2
+brew install libbluray
+brew install libcbor
+brew install libdeflate
+brew install libevent
+brew install libfido2
+brew install libgit2
 brew install libidn2
+brew install libmicrohttpd
 brew install libnghttp2
-brew install libnghttp3
-brew install libngtcp2
+brew install libogg
 brew install libpng
+brew install librist
 brew install librsvg
-brew install libsass
+brew install libsamplerate
+brew install libsndfile
+brew install libsodium
+brew install libsoxr
+brew install libssh
+brew install libssh2
+brew install libtasn1
 brew install libtiff
-brew install libtommath
+brew install libtool
+brew install libudfread
+brew install libunibreak
 brew install libunistring
 brew install libuv
+brew install libvidstab
+brew install libvmaf
+brew install libvorbis
+brew install libvpx
 brew install libx11
 brew install libxau
 brew install libxcb
 brew install libxdmcp
 brew install libxext
-brew install libxfixes
-brew install libxi
-brew install libxmlb
 brew install libxrender
-brew install libxtst
 brew install libyaml
+brew install little-cms2
+brew install luajit
 brew install lz4
 brew install lzo
+brew install m4
+brew install mas
+brew install maven
+brew install mbedtls
 brew install mpdecimal
-brew install mysql
+brew install mpg123
+brew install mysql@8.0
+brew install ncurses
+brew install netpbm
+brew install nettle
 brew install node
 brew install oniguruma
+brew install opencore-amr
+brew install openexr
+brew install openjdk
+brew install openjdk@11
+brew install openjdk@17
+brew install openjpeg
+brew install openjph
 brew install openssl@3
-brew install p7zip
+brew install opus
+brew install p11-kit
 brew install pandoc
 brew install pango
 brew install pcre2
+brew install pipx
 brew install pixman
-brew install poetry
+brew install plantuml
+brew install pnpm
 brew install protobuf@29
-brew install pycparser
-brew install python-packaging
-brew install python-tk@3.12
+brew install pulumi
+brew install python@3.11
 brew install python@3.12
 brew install python@3.13
+brew install rav1e
 brew install readline
-brew install simdjson
+brew install redis
+brew install redpanda
+brew install rubberband
+brew install sdl2
+brew install snappy
+brew install sonar-scanner
+brew install speex
 brew install sqlite
-brew install tcl-tk
-brew install unzip
-brew install uv
-brew install uvwasi
-brew install wget
-brew install winetricks
+brew install srt
+brew install stripe
+brew install svt-av1
+brew install telnet
+brew install terraform
+brew install tesseract
+brew install theora
+brew install tree
+brew install unbound
+brew install vault
+brew install virtualenv
+brew install webp
+brew install x264
+brew install x265
 brew install xorgproto
+brew install xvid
 brew install xz
-brew install zenity
+brew install yq
+brew install zeromq
+brew install zimg
 brew install zlib
+brew install zsh
+brew install zsh-completions
+brew install zsh-syntax-highlighting
 brew install zstd
-brew install dbeaver-community
-brew install flameshot
-brew install gstreamer-runtime
-brew install wine-stable
+brew install devtoys
+brew install gcloud-cli
+brew install google-cloud-sdk
 
 # Install Homebrew casks
-brew install --cask dbeaver-community
-brew install --cask flameshot
-brew install --cask gstreamer-runtime
-brew install --cask wine-stable
+brew install --cask devtoys
+brew install --cask gcloud-cli
+brew install --cask google-cloud-sdk
 
-# Note: mas is not installed. Install it with: brew install mas
+# Install Mac App Store applications
+mas install 1091189122
+mas install 462058435
+mas install 310633997
 
 # Install pip packages
-pip install --upgrade pip
+python3 -m pip install --upgrade pip
+python3 -m pip install aiohappyeyeballs==2.6.1
+python3 -m pip install aiohttp==3.12.15
+python3 -m pip install aiosignal==1.4.0
+python3 -m pip install annotated-types==0.7.0
+python3 -m pip install anyio==4.9.0
+python3 -m pip install attrs==25.3.0
+python3 -m pip install black==23.7.0
+python3 -m pip install blinker==1.9.0
+python3 -m pip install boto3==1.40.27
+python3 -m pip install botocore==1.40.27
+python3 -m pip install cachetools==5.5.2
+python3 -m pip install certifi==2025.7.9
+python3 -m pip install cfgv==3.4.0
+python3 -m pip install charset-normalizer==3.4.2
+python3 -m pip install click==8.2.1
+python3 -m pip install cloudevents==1.11.0
+python3 -m pip install contourpy==1.3.3
+python3 -m pip install coverage==7.10.6
+python3 -m pip install cramjam==2.11.0
+python3 -m pip install cycler==0.12.1
+python3 -m pip install db-dtypes==1.4.3
+python3 -m pip install decorator==5.2.1
+python3 -m pip install deprecation==2.1.0
+python3 -m pip install distlib==0.4.0
+python3 -m pip install et_xmlfile==2.0.0
+python3 -m pip install fastapi==0.115.12
+python3 -m pip install fastjsonschema==2.21.2
+python3 -m pip install fastparquet==2024.11.0
+python3 -m pip install filelock==3.19.1
+python3 -m pip install flake8==6.0.0
+python3 -m pip install Flask==3.1.1
+python3 -m pip install fonttools==4.59.0
+python3 -m pip install frozenlist==1.7.0
+python3 -m pip install fsspec==2025.5.1
+python3 -m pip install functions-framework==3.9.1
+python3 -m pip install gcsfs==2025.5.1
+python3 -m pip install google-api-core==2.25.1
+python3 -m pip install google-api-python-client==2.176.0
+python3 -m pip install google-auth==2.40.3
+python3 -m pip install google-auth-httplib2==0.2.0
+python3 -m pip install google-auth-oauthlib==1.2.2
+python3 -m pip install google-cloud-appengine-logging==1.6.2
+python3 -m pip install google-cloud-audit-log==0.3.2
+python3 -m pip install google-cloud-bigquery==3.34.0
+python3 -m pip install google-cloud-core==2.4.3
+python3 -m pip install google-cloud-dataplex==2.11.0
+python3 -m pip install google-cloud-dataproc==5.21.0
+python3 -m pip install google-cloud-logging==3.8.0
+python3 -m pip install google-cloud-secret-manager==2.24.0
+python3 -m pip install google-cloud-storage==3.2.0
+python3 -m pip install google-crc32c==1.7.1
+python3 -m pip install google-resumable-media==2.7.2
+python3 -m pip install googleapis-common-protos==1.70.0
+python3 -m pip install grpc-google-iam-v1==0.14.2
+python3 -m pip install grpcio==1.73.1
+python3 -m pip install grpcio-status==1.62.3
+python3 -m pip install gunicorn==23.0.0
+python3 -m pip install h11==0.16.0
+python3 -m pip install httpcore==1.0.9
+python3 -m pip install httplib2==0.22.0
+python3 -m pip install httpx==0.28.1
+python3 -m pip install identify==2.6.14
+python3 -m pip install idna==3.10
+python3 -m pip install iniconfig==2.1.0
+python3 -m pip install isort==6.0.1
+python3 -m pip install itsdangerous==2.2.0
+python3 -m pip install Jinja2==3.1.6
+python3 -m pip install jmespath==1.0.1
+python3 -m pip install joblib==1.5.1
+python3 -m pip install jsonschema==4.25.1
+python3 -m pip install jsonschema-specifications==2025.9.1
+python3 -m pip install jupyter_core==5.8.1
+python3 -m pip install kiwisolver==1.4.8
+python3 -m pip install llvmlite==0.44.0
+python3 -m pip install MarkupSafe==3.0.2
+python3 -m pip install matplotlib==3.10.3
+python3 -m pip install mccabe==0.7.0
+python3 -m pip install multidict==6.6.4
+python3 -m pip install mypy_extensions==1.1.0
+python3 -m pip install narwhals==2.0.0
+python3 -m pip install nbformat==5.10.4
+python3 -m pip install nodeenv==1.9.1
+python3 -m pip install numba==0.61.2
+python3 -m pip install numpy==1.26.4
+python3 -m pip install oauthlib==3.3.1
+python3 -m pip install openpyxl==3.1.5
+python3 -m pip install packaging==25.0
+python3 -m pip install pandas==2.3.0
+python3 -m pip install pandas-gbq==0.29.1
+python3 -m pip install pathspec==0.12.1
+python3 -m pip install patsy==1.0.1
+python3 -m pip install pillow==11.3.0
+python3 -m pip install platformdirs==4.3.8
+python3 -m pip install plotly==6.2.0
+python3 -m pip install pluggy==1.6.0
+python3 -m pip install pre_commit==4.2.0
+python3 -m pip install propcache==0.3.2
+python3 -m pip install proto-plus==1.26.1
+python3 -m pip install protobuf==4.25.8
+python3 -m pip install pyarrow==20.0.0
+python3 -m pip install pyasn1==0.6.1
+python3 -m pip install pyasn1_modules==0.4.2
+python3 -m pip install pycodestyle==2.10.0
+python3 -m pip install pydantic==2.11.7
+python3 -m pip install pydantic_core==2.33.2
+python3 -m pip install pydata-google-auth==1.9.1
+python3 -m pip install pyflakes==3.0.1
+python3 -m pip install Pygments==2.19.2
+python3 -m pip install pyparsing==3.2.3
+python3 -m pip install pytest==8.4.0
+python3 -m pip install pytest-cov==6.1.1
+python3 -m pip install pytest-mock==3.15.0
+python3 -m pip install python-dateutil==2.9.0.post0
+python3 -m pip install python-dotenv==1.0.0
+python3 -m pip install pytz==2025.2
+python3 -m pip install PyYAML==6.0.1
+python3 -m pip install ratelimit==2.2.1
+python3 -m pip install referencing==0.36.2
+python3 -m pip install requests==2.32.4
+python3 -m pip install requests-mock==1.12.1
+python3 -m pip install requests-oauthlib==2.0.0
+python3 -m pip install rpds-py==0.27.1
+python3 -m pip install rsa==4.9.1
+python3 -m pip install s3transfer==0.14.0
+python3 -m pip install scikit-learn==1.7.1
+python3 -m pip install scipy==1.16.1
+python3 -m pip install seaborn==0.13.2
+python3 -m pip install setuptools==80.9.0
+python3 -m pip install six==1.17.0
+python3 -m pip install slack_sdk==3.36.0
+python3 -m pip install sniffio==1.3.1
+python3 -m pip install sqlglot==27.13.2
+python3 -m pip install starlette==0.46.2
+python3 -m pip install statsmodels==0.14.5
+python3 -m pip install threadpoolctl==3.6.0
+python3 -m pip install tqdm==4.67.1
+python3 -m pip install traitlets==5.14.3
+python3 -m pip install typing-inspection==0.4.1
+python3 -m pip install typing_extensions==4.14.1
+python3 -m pip install tzdata==2025.2
+python3 -m pip install Unidecode==1.4.0
+python3 -m pip install uritemplate==4.2.0
+python3 -m pip install urllib3==1.26.20
+python3 -m pip install uvicorn==0.34.3
+python3 -m pip install uvicorn-worker==0.3.0
+python3 -m pip install virtualenv==20.34.0
+python3 -m pip install watchdog==6.0.0
+python3 -m pip install Werkzeug==3.1.3
+python3 -m pip install wheel==0.45.1
+python3 -m pip install xlrd==2.0.2
+python3 -m pip install yarl==1.20.1
 
 # Install global npm packages
-npm install -g corepack@0.34.0
-npm install -g npm@11.6.0
-npm install -g pnpm@10.15.1
+npm install -g @mermaid-js/mermaid-cli@11.10.1
+npm install -g commitizen@4.3.1
+npm install -g corepack@0.32.0
+npm install -g cz-customizable@7.4.0
+npm install -g markdownlint-cli@0.45.0
+npm install -g npm@10.9.2
+npm install -g task-master-ai@0.20.0
+
+# Restore Maven dependencies
+mvn dependency:resolve
+mvn dependency:resolve-plugins
+
+# Restore Gradle dependencies
+gradle dependencies
 # Installed macOS Applications
 echo 'Installing macOS applications...'
 # Note: You may need to manually install Visual Studio Code.app
+# Note: You may need to manually install Sourcetree.app
+# Note: You may need to manually install Claude.app
+# Note: You may need to manually install Figma.app
+# Note: You may need to manually install Rectangle.app
 # Note: You may need to manually install Microsoft Defender.app
-# Note: You may need to manually install OneDrive.app
+# Note: You may need to manually install Warp.app
 # Note: You may need to manually install Spotify.app
 # Note: You may need to manually install DBeaver.app
 # Note: You may need to manually install Cursor.app
-# Note: You may need to manually install Microsoft Word.app
+# Note: You may need to manually install Obsidian.app
+# Note: You may need to manually install Arc.app
 # Note: You may need to manually install Microsoft Excel.app
+# Note: You may need to manually install OrbStack.app
 # Note: You may need to manually install ChatGPT.app
+# Note: You may need to manually install WhatsApp.app
+# Note: You may need to manually install Outlook (PWA).app
 # Note: You may need to manually install Company Portal.app
-# Note: You may need to manually install Google Docs.app
-# Note: You may need to manually install Google Sheets.app
-# Note: You may need to manually install Google Slides.app
+# Note: You may need to manually install Gather.app
+# Note: You may need to manually install Bear.app
+# Note: You may need to manually install DevToys.app
+# Note: You may need to manually install Insomnia.app
 # Note: You may need to manually install Microsoft Edge.app
-# Note: You may need to manually install The Unarchiver.app
-# Note: You may need to manually install Postman.app
-# Note: You may need to manually install flameshot.app
+# Note: You may need to manually install iTerm.app
+# Note: You may need to manually install PyCharm CE.app
+# Note: You may need to manually install Microsoft OneDrive.app
+# Note: You may need to manually install Microsoft Teams.app
+# Note: You may need to manually install Slack.app
+# Note: You may need to manually install TeamViewerHost.app
+# Note: You may need to manually install Sublime Text.app


### PR DESCRIPTION
## Fix: macOS pip compatibility issue

### Problem
The `generate_reinstall_script.sh` script was failing with `pip: command not found` error on macOS systems where Python is installed via Homebrew.

### Solution
- Changed from `pip` to `python3 -m pip` which is the recommended way to invoke pip on macOS
- Added conditional check for Python3 availability before attempting pip operations
- This ensures the script works correctly with Homebrew-installed Python

### Changes
- `generate_reinstall_script.sh`: Updated pip commands to use `python3 -m pip`
- Added safety check with `command -v python3` before pip operations
- Generated `reinstall_packages.sh` now contains correct pip commands

### Testing
- ✅ Script runs without errors
- ✅ Generated reinstall script contains proper `python3 -m pip` commands
- ✅ No linting errors introduced

### Impact
- Fixes script execution on macOS systems with Homebrew Python
- Maintains compatibility with other systems
- Improves script robustness with availability checks

## Resumo por Sourcery

Corrigir a invocação do pip no macOS ao mudar para `python3 -m pip` e proteger o seu uso, em seguida, regenerar o script de reinstalação com pacotes Homebrew, pip, npm e mas expandidos e atualizar o README.

Correções de Bugs:
- Usar `python3 -m pip` em vez de `pip` no `generate_reinstall_script.sh` para corrigir a compatibilidade com o macOS
- Adicionar uma verificação da disponibilidade do `python3` antes de executar operações do `pip` no script de geração

Melhorias:
- Regenerar `reinstall_packages.sh` para usar `python3 -m pip` para pacotes `pip` e atualizar as listas de fórmulas Homebrew, casks e apps mas
- Atualizar instalações globais de pacotes `npm` e adicionar etapas de resolução de dependências Maven e Gradle
- Refinar as instruções de uso do README com formatação aprimorada

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix pip invocation on macOS by switching to python3 -m pip and guarding its usage, then regenerate the reinstall script with expanded Homebrew, pip, npm, and mas packages and update the README.

Bug Fixes:
- Use python3 -m pip instead of pip in the generate_reinstall_script.sh to fix macOS compatibility
- Add a check for python3 availability before running pip operations in the generation script

Enhancements:
- Regenerate reinstall_packages.sh to use python3 -m pip for pip packages and update Homebrew formula, cask, and mas app lists
- Update global npm package installations and add Maven and Gradle dependency resolution steps
- Refine README usage instructions with improved formatting

</details>